### PR TITLE
[WBCAMS-438] Modify SQL Insert statement

### DIFF
--- a/sql/WBCAMS-438-SAO_CareerTrek_Videos.sql
+++ b/sql/WBCAMS-438-SAO_CareerTrek_Videos.sql
@@ -8,16 +8,16 @@ INSERT INTO [dbo].[NOCVideos]
            ,[CareerTrekVideoID]
            ,[CareerTrekVideoPosition])
      VALUES
-        ((select ID from NOC where NOCCode = 7321), 'k8klzO8Jaco', 1) -- 175
-		   ,((select ID from NOC where NOCCode = 7521), '8oj2YxsdmQM', 1) -- 176
-		   ,((select ID from NOC where NOCCode = 6341), 'P_qh9m4lkcY', 1) -- 177
-		   ,((select ID from NOC where NOCCode = 2131), 'SmOXVn0NRjk', 1) -- 178
-		   ,((select ID from NOC where NOCCode = 4032), 'D6QlqkQu5mU', 0) -- 179
-		   ,((select ID from NOC where NOCCode = 4152), 'vtgOv5ap5IA', 1) -- 180
-		   ,((select ID from NOC where NOCCode = 2174), '8OoS_PLEMm0', 1) -- 181
-		   ,((select ID from NOC where NOCCode = 0213), 'GYV76mxDL4Q', 0) -- 182
-		   ,((select ID from NOC where NOCCode = 4214), 'Itg5PS29BKU', 1) -- 183
-		   ,((select ID from NOC where NOCCode = 7241), 'Iphb6H8B9W4', 1) -- 184
+        ((select ID from NOC where NOCCode = 7321), 'k8klzO8Jaco', 0) -- 175
+       ,((select ID from NOC where NOCCode = 7521), '8oj2YxsdmQM', 0) -- 176
+       ,((select ID from NOC where NOCCode = 6341), 'P_qh9m4lkcY', 0) -- 177
+       ,((select ID from NOC where NOCCode = 2131), 'SmOXVn0NRjk', 0) -- 178
+       ,((select ID from NOC where NOCCode = 4032), 'D6QlqkQu5mU', 0) -- 179
+       ,((select ID from NOC where NOCCode = 4152), 'vtgOv5ap5IA', 0) -- 180
+       ,((select ID from NOC where NOCCode = 2174), '8OoS_PLEMm0', 0) -- 181
+       ,((select ID from NOC where NOCCode = 0213), 'GYV76mxDL4Q', 0) -- 182
+       ,((select ID from NOC where NOCCode = 4214), 'Itg5PS29BKU', 0) -- 183
+       ,((select ID from NOC where NOCCode = 7241), 'Iphb6H8B9W4', 0) -- 184
 
 select count (*)
 from NOCVideos

--- a/sql/WBCAMS-438-SAO_CareerTrek_Videos.sql
+++ b/sql/WBCAMS-438-SAO_CareerTrek_Videos.sql
@@ -8,16 +8,35 @@ INSERT INTO [dbo].[NOCVideos]
            ,[CareerTrekVideoID]
            ,[CareerTrekVideoPosition])
      VALUES
-        ((select ID from NOC where NOCCode = 7321), 'k8klzO8Jaco', 0) -- 175
-       ,((select ID from NOC where NOCCode = 7521), '8oj2YxsdmQM', 0) -- 176
-       ,((select ID from NOC where NOCCode = 6341), 'P_qh9m4lkcY', 0) -- 177
-       ,((select ID from NOC where NOCCode = 2131), 'SmOXVn0NRjk', 0) -- 178
-       ,((select ID from NOC where NOCCode = 4032), 'D6QlqkQu5mU', 0) -- 179
-       ,((select ID from NOC where NOCCode = 4152), 'vtgOv5ap5IA', 0) -- 180
-       ,((select ID from NOC where NOCCode = 2174), '8OoS_PLEMm0', 0) -- 181
-       ,((select ID from NOC where NOCCode = 0213), 'GYV76mxDL4Q', 0) -- 182
-       ,((select ID from NOC where NOCCode = 4214), 'Itg5PS29BKU', 0) -- 183
-       ,((select ID from NOC where NOCCode = 7241), 'Iphb6H8B9W4', 0) -- 184
+        ((select ID from NOC where NOCCode = 7321), 'k8klzO8Jaco', (SELECT
+    ISNULL(MIN(CareerTrekVideoPosition), 1) - 1 FROM NOCVideos WHERE NOCId = (select id from NOC where NOCCode = 7321))) -- 175
+       
+       ,((select ID from NOC where NOCCode = 7521), '8oj2YxsdmQM', (SELECT
+    ISNULL(MIN(CareerTrekVideoPosition), 1) - 1 FROM NOCVideos WHERE NOCId = (select id from NOC where NOCCode = 7521))) -- 176
+       
+       ,((select ID from NOC where NOCCode = 6341), 'P_qh9m4lkcY', (SELECT
+    ISNULL(MIN(CareerTrekVideoPosition), 1) - 1 FROM NOCVideos WHERE NOCId = (select id from NOC where NOCCode = 6341))) -- 177
+       
+       ,((select ID from NOC where NOCCode = 2131), 'SmOXVn0NRjk', (SELECT
+    ISNULL(MIN(CareerTrekVideoPosition), 1) - 1 FROM NOCVideos WHERE NOCId = (select id from NOC where NOCCode = 2131))) -- 178
+                                                    
+       ,((select ID from NOC where NOCCode = 4032), 'D6QlqkQu5mU', (SELECT
+    ISNULL(MIN(CareerTrekVideoPosition), 1) - 1 FROM NOCVideos WHERE NOCId = (select id from NOC where NOCCode = 4032))) -- 179
+                                                    
+       ,((select ID from NOC where NOCCode = 4152), 'vtgOv5ap5IA', (SELECT
+    ISNULL(MIN(CareerTrekVideoPosition), 1) - 1 FROM NOCVideos WHERE NOCId = (select id from NOC where NOCCode = 4152))) -- 180
+                                                    
+       ,((select ID from NOC where NOCCode = 2174), '8OoS_PLEMm0', (SELECT
+    ISNULL(MIN(CareerTrekVideoPosition), 1) - 1 FROM NOCVideos WHERE NOCId = (select id from NOC where NOCCode = 2174))) -- 181
+                                                    
+       ,((select ID from NOC where NOCCode = 0213), 'GYV76mxDL4Q', (SELECT
+    ISNULL(MIN(CareerTrekVideoPosition), 1) - 1 FROM NOCVideos WHERE NOCId = (select id from NOC where NOCCode = 0213))) -- 182
+       
+    ,((select ID from NOC where NOCCode = 4214), 'Itg5PS29BKU', (SELECT
+    ISNULL(MIN(CareerTrekVideoPosition), 1) - 1 FROM NOCVideos WHERE NOCId = (select id from NOC where NOCCode = 4214))) -- 183
+                                                    
+       ,((select ID from NOC where NOCCode = 7241), 'Iphb6H8B9W4', (SELECT
+    ISNULL(MIN(CareerTrekVideoPosition), 1) - 1 FROM NOCVideos WHERE NOCId = (select id from NOC where NOCCode = 7241))) -- 184
 
 select count (*)
 from NOCVideos


### PR DESCRIPTION
From what I can tell, the video with the lowest `CareerTrekVideoPosition` in the `NOCVideos` table is shown on the https://www2.workbc.ca/careersearchtool/ sidebar.  The INSERT statement uses a subquery to look up the `MIN(CareerTrekVideoPosition)` for each video being updated.  In the event, no record exists in `NOCVideos` a new record is added with a `CareerTrekVideoPosition` = 0