### PR TITLE
Adding the condition "IF EXISTS" to the drop constraint query. 

### DIFF
--- a/SSOT/18-UpdateJobOpeningFromLMO2025.sql
+++ b/SSOT/18-UpdateJobOpeningFromLMO2025.sql
@@ -1,6 +1,6 @@
 --Drop the foreign keys and primary keys on Id column in JobOpening table.
 ALTER TABLE JobOpening
-DROP CONSTRAINT FK_JobOpening_NOC;
+DROP CONSTRAINT IF EXISTS FK_JobOpening_NOC;
 
 --Delete the existing data in Job Openings table.
 delete from JobOpening

--- a/SSOT/20-UpdateNOCOccupationGroupFromLMO2025.sql
+++ b/SSOT/20-UpdateNOCOccupationGroupFromLMO2025.sql
@@ -1,6 +1,6 @@
 --Drop the foreign keys and primary keys on Id column in NOCOccupationGroup table.
 ALTER TABLE NOCOccupationGroup
-DROP CONSTRAINT FK_NOCOccupationGroup_NOC;
+DROP CONSTRAINT IF EXISTS FK_NOCOccupationGroup_NOC;
 
 --Delete the existing data in NOCOccupationGroup table.
 delete from NOCOccupationGroup


### PR DESCRIPTION
This will prevent the script from erroring out if the constraint did not exist in the first place.